### PR TITLE
Hash Submission, Revelation, and Deposit Return

### DIFF
--- a/contracts/Bankshot.sol
+++ b/contracts/Bankshot.sol
@@ -8,6 +8,7 @@ contract Bankshot {
    struct Submission {
        bytes32 sHash;
        bytes revelation;
+       uint256 deposit;
    }
 
    mapping(address => Submission[]) submissions;
@@ -33,7 +34,8 @@ contract Bankshot {
     }
 
     function submitHash(bytes32 _hash) public payable paysMin {
-        submissions[msg.sender].push(Submission({ sHash: _hash, revelation: ""}));
+        uint256 deposit = msg.value - ethVig;
+        submissions[msg.sender].push(Submission({ sHash: _hash, revelation: "", deposit: deposit}));
     }
 
     function hashesForAddress(address _address) public view returns(bytes32[] memory) {
@@ -53,11 +55,14 @@ contract Bankshot {
 
     function revealSubmission(uint _subId, bytes memory _revelation) public {
         Submission storage sub = submissions[msg.sender][_subId];
+        require(sub.revelation.length == 0, "ALREADY_REVEALED");
 
         bytes32 revealHash = keccak256(abi.encodePacked(_revelation));
         require(revealHash == sub.sHash, "INVALID_REVEAL");
 
         sub.revelation = _revelation;
+
+        msg.sender.transfer(sub.deposit);
     }
 
     modifier onlyOwner() {

--- a/contracts/Bankshot.sol
+++ b/contracts/Bankshot.sol
@@ -5,6 +5,13 @@ contract Bankshot {
    uint256 public ethVig;
    uint256 public minEthDeposit;
 
+   struct Submission {
+       bytes32 sHash;
+       bytes revelation;
+   }
+
+   mapping(address => Submission[]) submissions;
+
     constructor(uint256 _ethVig,
                 uint256 _minEthDeposit) public {
 
@@ -25,8 +32,41 @@ contract Bankshot {
         minEthDeposit = _newMinEthDeposit;
     }
 
+    function submitHash(bytes32 _hash) public payable paysMin {
+        submissions[msg.sender].push(Submission({ sHash: _hash, revelation: ""}));
+    }
+
+    function hashesForAddress(address _address) public view returns(bytes32[] memory) {
+        Submission[] storage subs = submissions[_address];
+        bytes32[] memory hashes = new bytes32[](subs.length);
+
+        for(uint i = 0; i < subs.length; i++) {
+            hashes[i] = subs[i].sHash;
+        }
+
+        return hashes;
+    }
+
+    function revelationForSub(address _address, uint256 _subID) public view returns (bytes memory) {
+        return submissions[_address][_subID].revelation;
+    }
+
+    function revealSubmission(uint _subId, bytes memory _revelation) public {
+        Submission storage sub = submissions[msg.sender][_subId];
+
+        bytes32 revealHash = keccak256(abi.encodePacked(_revelation));
+        require(revealHash == sub.sHash, "INVALID_REVEAL");
+
+        sub.revelation = _revelation;
+    }
+
     modifier onlyOwner() {
         require(msg.sender == owner, "ONLY_OWNER");
+        _;
+    }
+
+    modifier paysMin() {
+        require(msg.value >= minEthPayable(), 'INSUFFICIENT_FUNDS');
         _;
     }
 }

--- a/test/bankshot.js
+++ b/test/bankshot.js
@@ -23,6 +23,19 @@ function addWeiStrings(...weiStrings) {
           .reduce( (acc, curr) => acc.add(curr) );
 }
 
+async function getGasCost(receipt) {
+  let gasUsed = new BN(receipt.cumulativeGasUsed);
+
+  let tx = await web3.eth.getTransaction(receipt.transactionHash);
+  let gasPrice = new BN(tx.gasPrice);
+
+  return gasPrice.mul(gasUsed);
+}
+
+String.prototype.toBN = function() {
+  return new BN(this.toString());
+}
+
 contract("Bankshot", accounts => {
 
   var bankshotInstance;
@@ -33,6 +46,7 @@ contract("Bankshot", accounts => {
   let initMinEthDeposit = utils.toWei('.03', 'ether');
   let newVig = utils.toWei('0.02', 'ether');
   let newMinEthDeposit = utils.toWei('0.05', 'ether');
+  let extraDeposit = utils.toWei('1', 'ether');
 
 
   it("should deploy", async () => {
@@ -119,7 +133,7 @@ contract("Bankshot", accounts => {
   it("should let another user submit a hash with above min payment", async () => {
     let string = "Hello, Cruel World";
     let hash = utils.soliditySha3({type: 'string', value: string});
-    let txValue = addWeiStrings(newVig, newMinEthDeposit, utils.toWei('1', 'ether'));
+    let txValue = addWeiStrings(newVig, extraDeposit);
     
     await bankshotInstance.submitHash(hash, {from: user2Addr, value: txValue});
 
@@ -148,7 +162,7 @@ contract("Bankshot", accounts => {
     await assertRevert(txPromise, 'INSUFFICIENT_FUNDS', "Failed to revert submission w/ insufficient payment");
   });
 
-  it("should or should not let a user submit and reveal a string", async () => {
+  it("should not let a user claim a reveal if the string is incorrect", async () => {
     let string = "Hello Again";
     let hash = utils.soliditySha3({type: 'string', value: string});
     let txValue = addWeiStrings(newVig, newMinEthDeposit);
@@ -161,13 +175,24 @@ contract("Bankshot", accounts => {
 
     let wrongRevealTx = bankshotInstance.revealSubmission(1, utils.toHex(string + "!!"), {from: user1Addr});
     await assertRevert(wrongRevealTx, "INVALID_REVEAL", "Revealed when it shouldn't have");
-
-    await bankshotInstance.revealSubmission(1, utils.toHex(string), {from: user1Addr});
   });
 
   it("should not show a revelation for a submission that hasn't been revealed", async () => {
     let revelation = await bankshotInstance.revelationForSub(user2Addr, 0);
     assert.equal(revelation, null, "Returned a non-null value for an unrevealed submission");
+  });
+
+  it("should pay a user back for a correct revelation", async () => {
+    let string = "Hello Again";
+    let initBalance = ( await web3.eth.getBalance(user1Addr) ).toBN();
+
+    let result = await bankshotInstance.revealSubmission(1, utils.toHex(string), {from: user1Addr});
+    let gasCost = await getGasCost(result.receipt);
+
+    let postBalance = ( await web3.eth.getBalance(user1Addr) ).toBN();
+    let amountReturned = postBalance.add(gasCost).sub(initBalance);
+
+    assert.equal(newMinEthDeposit, amountReturned.toString(10), "Failed to return a user's minimum deposit");
   });
 
   it("should return the reveal string for a previously revealed submission", async () => {
@@ -177,5 +202,27 @@ contract("Bankshot", accounts => {
     let revelationString = utils.hexToUtf8(revelationBytes);
 
     assert.equal(revelationString, expectedString, "Failed to return the revelation string");
+  });
+
+  it("should not allow a user to reveal a submission twice", async () => {
+    let string = "Hello Again";
+
+    let revealTx = bankshotInstance.revealSubmission(1, utils.toHex(string), {from: user1Addr});
+
+    await assertRevert(revealTx, "ALREADY_REVEALED", "Allowed the user to reveal the same submission twice");
+  });
+
+  it("should pay back a user who deposited more than the minimum the correct amount", async () => {
+    let string = "Hello, Cruel World";
+
+    let initBalance = ( await web3.eth.getBalance(user2Addr) ).toBN();
+
+    let result = await bankshotInstance.revealSubmission(0, utils.toHex(string), {from: user2Addr});
+    let gasCost = await getGasCost(result.receipt);
+
+    let postBalance = ( await web3.eth.getBalance(user2Addr) ).toBN();
+    let amountReturned = postBalance.add(gasCost).sub(initBalance);
+
+    assert.equal(extraDeposit, amountReturned.toString(10), "Failed to return a user's extra deposit");
   });
 });


### PR DESCRIPTION
Implement a simple commit-reveal scheme for prediction submissions. Require deposit + vig on submission, payback deposit on validated revelation.